### PR TITLE
require relative path

### DIFF
--- a/lib/websocket-eventmachine-server.rb
+++ b/lib/websocket-eventmachine-server.rb
@@ -1,1 +1,1 @@
-require File.expand_path('../websocket/eventmachine/server', __FILE__)
+require 'websocket/eventmachine/server'


### PR DESCRIPTION
graceful, and require a absolute path will cause a crash in packaged(eg. exerb) applications.
